### PR TITLE
Adding tpu capabilities to train.py

### DIFF
--- a/fairseq/checkpoint_utils.py
+++ b/fairseq/checkpoint_utils.py
@@ -135,6 +135,19 @@ def load_checkpoint(args, trainer):
     return extra_state, epoch_itr
 
 
+def load_checkpoint_tpu(args, trainers, device_preloaded):
+    for device, trainer in trainers.items():
+        if device != device_preloaded:
+            _ = trainer.load_checkpoint(
+                get_checkpoint_path(args),
+                reset_optimizer=args.reset_optimizer,
+                reset_lr_scheduler=args.reset_lr_scheduler,
+                optimizer_overrides=eval(args.optimizer_overrides),
+                reset_meters=args.reset_meters,
+            )
+        trainer.meters_to_device(device)
+
+
 def load_checkpoint_to_cpu(path, arg_overrides=None):
     """Loads a checkpoint to CPU (with upgrading for backward compatibility)."""
     state = torch.load(

--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -43,7 +43,6 @@ def collate_tokens(
 ):
     """Convert a list of 1d tensors into a padded 2d tensor."""
     size = get_pad_size(values, input_shapes)
-    max(v.size(0) for v in values)
     res = values[0].new(len(values), size).fill_(pad_idx)
 
     def copy_tensor(src, dst):

--- a/fairseq/data/data_utils.py
+++ b/fairseq/data/data_utils.py
@@ -24,9 +24,26 @@ def infer_language_pair(path):
     return src, dst
 
 
-def collate_tokens(values, pad_idx, eos_idx=None, left_pad=False, move_eos_to_beginning=False):
+def get_pad_size(values, input_shapes):
+    if input_shapes is None:
+        return max(v.size(0) for v in values)
+    for batch_size, padlen in input_shapes:
+        if len(values) == batch_size:
+            return padlen
+    else:
+        raise IndexError(
+            'Encountered values with invalid length {}, input shapes were {}'
+            .format(len(values), input_shapes)
+        )
+
+
+def collate_tokens(
+    values, pad_idx, eos_idx=None, left_pad=False,
+    move_eos_to_beginning=False, input_shapes=None,
+):
     """Convert a list of 1d tensors into a padded 2d tensor."""
-    size = max(v.size(0) for v in values)
+    size = get_pad_size(values, input_shapes)
+    max(v.size(0) for v in values)
     res = values[0].new(len(values), size).fill_(pad_idx)
 
     def copy_tensor(src, dst):
@@ -187,8 +204,24 @@ def batch_by_size(
 
         batch.append(idx)
 
-    # if len(batch) > 0:
-    #     yield batch
+    if len(batch) > 0:
+        yield batch
+
+
+def batch_by_size_tpu(
+    indices, num_tokens_fn, input_shapes
+):
+    batches = [[] for _ in input_shapes]
+    for idx in indices:
+        sample_len = num_tokens_fn(idx)
+        for j, (batch_size, padlen) in enumerate(input_shapes):
+            if padlen < sample_len:
+                continue
+            batches[j].append(idx)
+            if len(batches[j]) == batch_size:
+                yield batches[j]
+                batches[j] = []
+            break
 
 
 def process_bpe_symbol(sentence: str, bpe_symbol: str):

--- a/fairseq/data/language_pair_dataset.py
+++ b/fairseq/data/language_pair_dataset.py
@@ -13,15 +13,15 @@ from . import data_utils, FairseqDataset
 
 def collate(
     samples, pad_idx, eos_idx, left_pad_source=True, left_pad_target=False,
-    input_feeding=True,
+    input_feeding=True, input_shapes=None,
 ):
     if len(samples) == 0:
         return {}
 
     def merge(key, left_pad, move_eos_to_beginning=False):
         return data_utils.collate_tokens(
-            [s[key] for s in samples],
-            pad_idx, eos_idx, left_pad, move_eos_to_beginning,
+            [s[key] for s in samples], pad_idx,
+            eos_idx,left_pad, move_eos_to_beginning, input_shapes,
         )
 
     id = torch.LongTensor([s['id'] for s in samples])
@@ -102,6 +102,7 @@ class LanguagePairDataset(FairseqDataset):
         left_pad_source=True, left_pad_target=False,
         max_source_positions=1024, max_target_positions=1024,
         shuffle=True, input_feeding=True, remove_eos_from_source=False, append_eos_to_target=False,
+        input_shapes=None,
     ):
         if tgt_dict is not None:
             assert src_dict.pad() == tgt_dict.pad()
@@ -121,6 +122,7 @@ class LanguagePairDataset(FairseqDataset):
         self.input_feeding = input_feeding
         self.remove_eos_from_source = remove_eos_from_source
         self.append_eos_to_target = append_eos_to_target
+        self.input_shapes = input_shapes
 
     def __getitem__(self, index):
         tgt_item = self.tgt[index] if self.tgt is not None else None
@@ -180,7 +182,7 @@ class LanguagePairDataset(FairseqDataset):
         return collate(
             samples, pad_idx=self.src_dict.pad(), eos_idx=self.src_dict.eos(),
             left_pad_source=self.left_pad_source, left_pad_target=self.left_pad_target,
-            input_feeding=self.input_feeding,
+            input_feeding=self.input_feeding, input_shapes=self.input_shapes,
         )
 
     def num_tokens(self, index):

--- a/fairseq/tasks/fairseq_task.py
+++ b/fairseq/tasks/fairseq_task.py
@@ -138,9 +138,8 @@ class FairseqTask(object):
             )
 
         # create mini-batches with given size constraints
-        batch_sampler = data_utils.batch_by_size(
-            indices, dataset.num_tokens, max_tokens=max_tokens, max_sentences=max_sentences,
-            required_batch_size_multiple=required_batch_size_multiple,
+        batch_sampler = data_utils.batch_by_size_tpu(
+            indices, dataset.num_tokens, self.args.input_shapes
         )
 
         # return a reusable, sharded iterator

--- a/fairseq/tasks/translation.py
+++ b/fairseq/tasks/translation.py
@@ -25,6 +25,7 @@ def load_langpair_dataset(
     tgt, tgt_dict,
     combine, dataset_impl, upsample_primary,
     left_pad_source, left_pad_target, max_source_positions, max_target_positions,
+    input_shapes,
 ):
     def split_exists(split, src, tgt, lang, data_path):
         filename = os.path.join(data_path, '{}.{}-{}.{}'.format(split, src, tgt, lang))
@@ -74,6 +75,7 @@ def load_langpair_dataset(
         left_pad_target=left_pad_target,
         max_source_positions=max_source_positions,
         max_target_positions=max_target_positions,
+        input_shapes=input_shapes,
     )
 
 
@@ -186,6 +188,7 @@ class TranslationTask(FairseqTask):
             left_pad_target=self.args.left_pad_target,
             max_source_positions=self.args.max_source_positions,
             max_target_positions=self.args.max_target_positions,
+            input_shapes=self.args.input_shapes,
         )
 
     def build_dataset_for_inference(self, src_tokens, src_lengths):

--- a/fairseq/trainer.py
+++ b/fairseq/trainer.py
@@ -494,6 +494,14 @@ class Trainer(object):
             return None
         return self.meters[name]
 
+    def meters_to_device(self, device):
+        """Send meters' values to given device. Useful for TPU's."""
+        for meter in self.meters.values():
+            for key, val in vars(meter).items():
+                if isinstance(val, torch.Tensor):
+                    newval = val.to(device=torch.device(device))
+                    setattr(meter, key, newval)
+
     def get_num_updates(self):
         """Get the number of parameters updates."""
         return self._num_updates

--- a/train.py
+++ b/train.py
@@ -357,8 +357,8 @@ def main_tpu(args):
                 print(
                     log_step(
                         'training', device, i,
-                        log_output=log_output, tracker=tracker
-                    )
+                        log_output=log_output, tracker=tracker),
+                    flush=True,
                 )
             log_output = trainer.train_step(samples)
             xm.optimizer_step(trainer.optimizer)

--- a/train.py
+++ b/train.py
@@ -13,13 +13,44 @@ import collections
 import math
 import os
 import random
+from datetime import datetime
 
 import torch
+import torch_xla
+import torch_xla.distributed.data_parallel as dp
+import torch_xla.utils.utils as xu
+import torch_xla.core.xla_model as xm
 
 from fairseq import checkpoint_utils, distributed_utils, options, progress_bar, tasks, utils
 from fairseq.data import iterators
 from fairseq.trainer import Trainer
 from fairseq.meters import AverageMeter, StopwatchMeter
+
+
+def initialize_loader_for_epoch(args, epoch_itr):
+    # Update parameters every N batches
+    if epoch_itr.epoch <= len(args.update_freq):
+        update_freq = args.update_freq[epoch_itr.epoch - 1]
+    else:
+        update_freq = args.update_freq[-1]
+
+    # Initialize data iterator
+    itr = epoch_itr.next_epoch_itr(
+          fix_batches_to_gpus=False, shuffle=(epoch_itr.epoch >= args.curriculum))
+    itr = iterators.GroupedIterator(itr, update_freq)
+    progress = progress_bar.build_progress_bar(
+          args, itr, epoch_itr.epoch, prefix='training', no_progress_bar='simple')
+    return progress
+
+
+def print_model_criterion(model, criterion, args):
+      print(model)
+      print('| model {}, criterion {}'.format(args.arch,
+                                              criterion.__class__.__name__))
+      print('| num. model params: {} (num. trained: {})'.format(
+          sum(p.numel() for p in model.parameters()),
+          sum(p.numel() for p in model.parameters() if p.requires_grad),
+      ))
 
 
 def main(args, init_distributed=False):
@@ -48,12 +79,7 @@ def main(args, init_distributed=False):
     # Build model and criterion
     model = task.build_model(args)
     criterion = task.build_criterion(args)
-    print(model)
-    print('| model {}, criterion {}'.format(args.arch, criterion.__class__.__name__))
-    print('| num. model params: {} (num. trained: {})'.format(
-        sum(p.numel() for p in model.parameters()),
-        sum(p.numel() for p in model.parameters() if p.requires_grad),
-    ))
+    print_model_criterion(model, criterion, args)
 
     # Build trainer
     trainer = Trainer(args, task, model, criterion)
@@ -100,20 +126,7 @@ def main(args, init_distributed=False):
 
 def train(args, trainer, task, epoch_itr):
     """Train the model for one epoch."""
-    # Update parameters every N batches
-    update_freq = args.update_freq[epoch_itr.epoch - 1] \
-        if epoch_itr.epoch <= len(args.update_freq) else args.update_freq[-1]
-
-    # Initialize data iterator
-    itr = epoch_itr.next_epoch_itr(
-        fix_batches_to_gpus=args.fix_batches_to_gpus,
-        shuffle=(epoch_itr.epoch >= args.curriculum),
-    )
-    itr = iterators.GroupedIterator(itr, update_freq)
-    progress = progress_bar.build_progress_bar(
-        args, itr, epoch_itr.epoch, no_progress_bar='simple',
-    )
-
+    progress = initialize_loader_for_epoch(args, epoch_itr)
     extra_meters = collections.defaultdict(lambda: AverageMeter())
     valid_subsets = args.valid_subset.split(',')
     max_update = args.max_update or math.inf
@@ -264,42 +277,317 @@ def distributed_main(i, args, start_rank=0):
         args.distributed_rank = start_rank + i
     main(args, init_distributed=True)
 
+def parse_input_shapes(input_shapes_arg):
+    input_shapes = (
+        shape.replace('*', 'x').split('x') for shape in input_shapes_arg)
+    input_shapes = [list(map(int, shape)) for shape in input_shapes]
+    if len(input_shapes) == 1:
+        return input_shapes
+    input_shapes.sort(key=lambda shape: shape[1])
+    errmsg = (
+        'Invalid --input_shapes. Batch sizes (dimension 1) need to increase as '
+        'num_tokens (dimension 2) decrease. e.g. 16x128 32x64 64x32'
+    )
+    assert all(
+         shape1[0] > shape2[0]
+         for shape1, shape2 in zip(input_shapes, input_shapes[1:])), errmsg
+    return input_shapes
+
+
+def main_tpu(args):
+
+    def now():
+        return datetime.now().strftime('%H:%M:%S')
+
+    def log_step(step_type, device, step, log_output=None, tracker=None):
+        msg = '{}/ {}, device {}, step {}'.format(
+            step_type, now(), device, step
+        )
+        if tracker:
+            rates = tracker.rate(), tracker.global_rate()
+            msg += ', Rate={:.2f}, GlobalRate={:.2f}'.format(*rates)
+        if log_output:
+            msg += ', loss={:.4f}, nll_loss={:.4f}'.format(
+                log_output['loss'].item(), log_output['nll_loss'].item()
+            )
+        return msg
+
+    def prepare_task(args, devices):
+        # Setup task, e.g., translation, language modeling, etc.
+        task = tasks.setup_task(args)
+
+        # Load valid dataset (we load training data below, based on the latest checkpoint)
+        for valid_sub_split in args.valid_subset.split(','):
+            task.load_dataset(valid_sub_split, combine=True, epoch=0)
+
+        # Build models and criteria to print some metadata
+        model_parallel = dp.DataParallel(
+            lambda: task.build_model(args), device_ids=devices)
+        model, criterion = task.build_model(args), task.build_criterion(args)
+        print_model_criterion(model, criterion, args)
+        del model, criterion
+
+        # Build trainers
+        trainers = {
+            device: Trainer(args, task, model, task.build_criterion(args), xla=True)
+            for device, model in zip(model_parallel.devices, model_parallel.models)
+        }
+        lr = trainers[devices[0]].get_lr()
+
+        # Load the latest checkpoint if one is available and restore the
+        # corresponding train iterator
+        extra_state, epoch_itr = checkpoint_utils.load_checkpoint(
+            args, trainers[devices[0]])
+        if extra_state is not None:
+            # checkpoint detected, load saved model weights to all devices
+            xu.eprint(
+                'checkpoint detected, device 0 meters need to be '
+                're-loaded to device'
+            )
+            checkpoint_utils.load_checkpoint_tpu(args, trainers, devices[0])
+        valid_subsets = args.valid_subset.split(',')
+        return task, trainers, model_parallel, epoch_itr, lr, valid_subsets
+
+    def train_loop_fn(model, loader, device, context):
+        trainer = trainers[str(device)]
+        stats, log_output = None, None
+        tracker = xm.RateTracker()
+        for i, samples in loader:
+            if i and not (i % args.log_steps):
+                print(
+                    log_step(
+                        'training', device, i,
+                        log_output=log_output, tracker=tracker
+                    )
+                )
+            log_output = trainer.train_step(samples)
+            xm.optimizer_step(trainer.optimizer)
+            tracker.add(sum(sample['nsentences'] for sample in samples))
+        return tracker
+
+    def valid_loop_fn(model, loader, device, context):
+        trainer = trainers[str(device)]
+        # reset validation loss meters
+        for k in ['valid_loss', 'valid_nll_loss']:
+            meter = trainer.get_meter(k)
+            if meter is not None:
+                meter.reset()
+        extra_meters = collections.defaultdict(lambda: AverageMeter())
+        for i, sample in loader:
+            if not (i % args.log_steps):
+                print(log_step('validation', device, i, tracker=None))
+            log_output = trainer.valid_step(sample)
+            for k, v in log_output.items():
+                if k in ['loss', 'nll_loss', 'ntokens', 'nsentences', 'sample_size']:
+                    continue
+                extra_meters[k].update(v)
+        stats = get_valid_stats(trainer)
+        for k, meter in extra_meters.items():
+            stats[k] = meter.avg
+        return stats
+
+    def validate_subset(args, trainers, task, epoch_itr, subset):
+        print('Validating the subset "{}"'.format(subset))
+        # Initialize data iterator
+        itr = task.get_batch_iterator(
+            dataset=task.dataset(subset),
+            max_tokens=args.max_tokens,
+            max_sentences=args.max_sentences_valid,
+            max_positions=utils.resolve_max_positions(
+                task.max_positions(),
+                list(trainers.values())[0].get_model().max_positions(),
+            ),
+            ignore_invalid_inputs=args.skip_invalid_size_inputs_valid_test,
+            required_batch_size_multiple=args.required_batch_size_multiple,
+            seed=args.seed,
+            num_workers=args.num_workers
+        ).next_epoch_itr(shuffle=False)
+        progress = progress_bar.build_progress_bar(
+            args, itr, epoch_itr.epoch,
+            prefix='valid on \'{}\' subset'.format(subset),
+            no_progress_bar='simple'
+        )
+        stats_per_device = model_parallel(valid_loop_fn, progress)
+        valid_losses = [stats['loss'].avg for stats in stats_per_device]
+        print('validation stats on subset "{}" - {}'.format(subset, now()))
+        for stats in stats_per_device:
+            progress.print(
+                stats, tag=subset, step=trainers['xla:1'].get_num_updates()
+            )
+        return valid_losses
+
+    def validate_subsets(args, trainers, task, epoch_itr, subsets):
+        valid_losses = {
+            subset: validate_subset(args, trainers, task, epoch_itr, subset)
+            for subset in subsets
+        }
+        return valid_losses
+
+    def keep_training(lr, epoch_itr, trainers):
+        # Train until the learning rate gets too small
+        max_epoch = args.max_epoch or math.inf
+        max_update = args.max_update or math.inf
+        lr = min(trainer.get_lr() for trainer in trainers.values())
+        n_updates = max(trainer.get_num_updates() for trainer in trainers.values())
+        return ((lr > args.min_lr) and (epoch_itr.epoch < max_epoch) and
+            (n_updates < max_update))
+
+    xu.eprint('Args')
+    for key, val in args.__dict__.items():
+        xu.eprint('\t{} {}'.format(key, val))
+
+    devices = xm.get_xla_supported_devices(max_devices=args.num_cores)
+    task, trainers, model_parallel, epoch_itr, lr, valid_subsets = prepare_task(
+        args, devices)
+
+    train_meter = StopwatchMeter()
+    train_meter.start()
+    while keep_training(lr, epoch_itr, trainers):
+        # TRAINING
+        print('Epoch {} begin {}'.format(epoch_itr.epoch + 1, now()))
+        progress = initialize_loader_for_epoch(args, epoch_itr)
+        trackers = model_parallel(train_loop_fn, progress)
+        print('Epoch {} Training stats:'.format(epoch_itr.epoch))
+        for device, trainer in trainers.items():
+            stats = get_training_stats(trainer)
+            print('device {}'.format(device))
+            progress.print(stats, tag=device)
+        print('Epoch {} Tracker Rates:'.format(epoch_itr.epoch))
+        for tracker in trackers:
+            rates = tracker.rate(), tracker.global_rate()
+            print('\tRate={:.2f}, GlobalRate={:.2f}'.format(*rates))
+        print('Epoch {} end {}'.format(epoch_itr.epoch, now()))
+        if args.metrics_debug:
+            print(torch_xla._XLAC._xla_metrics_report())
+
+        # VALIDATION
+        if not args.disable_validation and epoch_itr.epoch % args.validate_interval == 0:
+            valid_losses = validate_subsets(
+                args, trainers, task, epoch_itr, valid_subsets
+            )
+
+            # only use average first validation loss from the first device
+            # to update the learning rate
+            vloss = valid_losses[valid_subsets[0]][0].item()
+            print('old learning rate: {}'.format(lr))
+            lr = trainers[devices[0]].lr_step(epoch_itr.epoch, vloss)
+            print('new learning rate: {}'.format(lr))
+        else:
+            vloss = None
+
+        # save checkpoint
+        if epoch_itr.epoch % args.save_interval == 0:
+            checkpoint_utils.save_checkpoint(
+                args, trainers[devices[0]], epoch_itr, vloss)
+
+        if args.metrics_debug:
+            print(torch_xla._XLAC._xla_metrics_report())
+
+    train_meter.stop()
+    print('| done training in {:.1f} seconds'.format(train_meter.sum))
+
+
 
 def cli_main():
     parser = options.get_training_parser()
+
+    # TPU: need to control certain flags here.
+    # e.g. parallelization needs to be suppressed and deferred to torch_xla flags
+    # e.g. input tensor shapes need to be controlled via --input_shapes
+    parser.add_argument(
+        '--input_shapes',
+        nargs='*',
+        default=None,
+        help=(
+            'This is used to specify batches and pad lengths. Ex: '
+            '`--input_shapes 256x32 512x16` will produce batches w/ 256 '
+            'sentences padded to length 32, or 512 sentences padded to length '
+            '16. Including too many input shapes will cause graph recompiles and'
+            ' degrade performance. On the other extreme, including 1 shape may '
+            'waste a ton of flops, since batches may contain a lot of pad '
+            'indices on average. Note that the max pad length in this arg will '
+            'be used as `--max-source-positions`'))
+    parser.add_argument('--log_steps', type=int, default=20)
+    parser.add_argument('--num_cores', type=int, default=8)
+    parser.add_argument('--metrics_debug', action='store_true')
+    parser.add_argument('--use_gpu', action='store_true')
     args = options.parse_args_and_arch(parser)
 
-    if args.distributed_init_method is None:
-        distributed_utils.infer_init_method(args)
+    if args.use_gpu:
+        if args.distributed_init_method is None:
+            distributed_utils.infer_init_method(args)
 
-    if args.distributed_init_method is not None:
-        # distributed training
-        if torch.cuda.device_count() > 1 and not args.distributed_no_spawn:
-            start_rank = args.distributed_rank
-            args.distributed_rank = None  # assign automatically
+        if args.distributed_init_method is not None:
+            # distributed training
+            if torch.cuda.device_count() > 1 and not args.distributed_no_spawn:
+                start_rank = args.distributed_rank
+                args.distributed_rank = None  # assign automatically
+                torch.multiprocessing.spawn(
+                    fn=distributed_main,
+                    args=(args, start_rank),
+                    nprocs=torch.cuda.device_count(),
+                )
+            else:
+                distributed_main(args.device_id, args)
+        elif args.distributed_world_size > 1:
+            # fallback for single node with multiple GPUs
+            assert args.distributed_world_size <= torch.cuda.device_count()
+            port = random.randint(10000, 20000)
+            args.distributed_init_method = 'tcp://localhost:{port}'.format(port=port)
+            args.distributed_rank = None  # set based on device id
+            if max(args.update_freq) > 1 and args.ddp_backend != 'no_c10d':
+                print('| NOTE: you may get better performance with: --ddp-backend=no_c10d')
             torch.multiprocessing.spawn(
                 fn=distributed_main,
-                args=(args, start_rank),
-                nprocs=torch.cuda.device_count(),
+                args=(args, ),
+                nprocs=args.distributed_world_size,
             )
         else:
-            distributed_main(args.device_id, args)
-    elif args.distributed_world_size > 1:
-        # fallback for single node with multiple GPUs
-        assert args.distributed_world_size <= torch.cuda.device_count()
-        port = random.randint(10000, 20000)
-        args.distributed_init_method = 'tcp://localhost:{port}'.format(port=port)
-        args.distributed_rank = None  # set based on device id
-        if max(args.update_freq) > 1 and args.ddp_backend != 'no_c10d':
-            print('| NOTE: you may get better performance with: --ddp-backend=no_c10d')
-        torch.multiprocessing.spawn(
-            fn=distributed_main,
-            args=(args, ),
-            nprocs=args.distributed_world_size,
+            # single GPU training
+            main(args)
+        return
+
+    # From here on out we are in TPU context
+
+    if args.fp16:
+        raise RuntimeError(
+            '--fp16 was provided, this is controlled by env var XLA_USE_BF16')
+    if args.distributed_world_size > 1:
+        xu.eprint('suppressing "distributed_world_size"')
+        args.distributed_world_size = 1
+    if args.distributed_init_method is not None:
+        xu.eprint('suppressing "distributed_init_method"')
+        args.distributed_init_method = None
+    if args.input_shapes is None:
+        raise RuntimeError(
+            'Please specify batches and pad lengths using '
+            '--input_shapes. Ex: `--input_shapes 256x32 512x16` .'
+            'Please refer to the description of the --input_shape'
+            ' arg in --help'
         )
-    else:
-        # single GPU training
-        main(args)
+    gpu_input_shape_args = ['max_sentences', 'max_sentences_valid', 'max_tokens']
+    nonnull_gpu_input_shape_args = [
+        arg for arg in gpu_input_shape_args if getattr(args, arg) is not None
+    ]
+    if nonnull_gpu_input_shape_args:
+      errmsg = (
+          'On TPUs, please control input shapes '
+          'using `--input_shapes`. Any non-null arg in {} will trigger'
+          ' this error.'
+      ).format(gpu_input_shape_args)
+      raise RuntimeError(errmsg)
+
+    args.input_shapes = parse_input_shapes(args.input_shapes)
+    # XXX (taylanbil): do we ever have more than 2 dimensions in fairseq?
+    args.max_source_positions = args.input_shapes[-1][1]
+    if xu.getenv_as('XLA_USE_BF16', bool, False):
+        xu.eprint(
+            'WARNING: bfloat16 is enabled. Note that fairseq meters such as '
+            'loss will accumulate the numerator, and increment the denominator. '
+            'Due to lack of precision in higher numbers in bfloat16, these '
+            'meters will report invalid values after a while.')
+
+    main_tpu(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR will create the `tpu` branch in our forked fairseq repo.

Addressed Soumith's comments from https://github.com/pytorch-tpu/fairseq/pull/7

main file with changes is train.py. This file now has the bulk of `pytorch-tpu/examples/fairseq_train_tpu.py` which is going away once this pr is checked in.

Other files that are changed contain changes from pytorch-tpu/examples/fairseq_train_tpu.py as well.