### PR TITLE
Fix tensorboard logging, and add tboard logging consumable by the OSS metrics handler

### DIFF
--- a/fairseq/progress_bar.py
+++ b/fairseq/progress_bar.py
@@ -13,7 +13,10 @@ from numbers import Number
 import os
 import sys
 
+import torch
+
 import torch_xla.core.xla_model as xm
+import torch_xla.test.test_utils as test_utils
 
 from fairseq import distributed_utils
 from fairseq.meters import AverageMeter, StopwatchMeter, TimeMeter
@@ -53,14 +56,14 @@ def build_progress_bar(args, iterator, epoch=None, prefix=None, default='tqdm', 
         and getattr(args, 'use_gpu', True)
         and distributed_utils.is_master(args)
     ):
-        bar = tensorboard_log_wrapper(bar, logdir, args)
+        bar = tensorboard_log_wrapper(bar, args.tensorboard_logdir, args)
     elif args.tensorboard_logdir and not getattr(args, 'use_gpu', True):
         # tpu-comment: making every core have a tensorboard writer guarantees
         #   the same work accross cores.
         logdir = os.path.join(
             args.tensorboard_logdir, str(xm.get_local_ordinal())
         )
-        bar = tensorboard_log_wrapper(bar, logdir, args)
+        bar = tensorboard_log_wrapper_xla(bar, logdir, args)
     return bar
 
 
@@ -327,6 +330,41 @@ class tensorboard_log_wrapper(progress_bar):
             step = stats['num_updates']
         for key in stats.keys() - {'num_updates'}:
             if isinstance(stats[key], AverageMeter):
-                writer.add_scalar(key, stats[key].val, step)
+                logval = stats[key].val
+                if isinstance(logval, torch.Tensor):
+                    logval = logval.item()
+                writer.add_scalar(key, logval, step)
             elif isinstance(stats[key], Number):
                 writer.add_scalar(key, stats[key], step)
+
+
+class tensorboard_log_wrapper_xla(tensorboard_log_wrapper):
+    """
+    Pytorch/XLA OSS testing framework require tensorboard summary writers
+    to behave in a specific way. This wrapper class handles that case.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.writer_tag = 'run'
+
+    def _log_to_tensorboard(self, stats, tag='', step=None):
+        super()._log_to_tensorboard(
+            {'{}-{}'.format(tag, key): val for key, val in stats.items()},
+            tag=self.writer_tag, step=step
+        )
+
+    def log_xla_metrics(self, stats, tag='', step=None, *args, **kwargs):
+        writer = self._writer(self.writer_tag)
+        test_utils.write_to_summary(
+            summary_writer=writer, global_step=step, dict_to_write={},
+            write_xla_metrics=True,
+        )
+        writer.flush()
+
+
+def progress_bar_print(bar, stats, *args, **kwargs):
+    log_xla_metrics = kwargs.pop('log_xla_metrics', False)
+    bar.print(stats, *args, **kwargs)
+    if isinstance(bar, tensorboard_log_wrapper_xla) and log_xla_metrics:
+        bar.log_xla_metrics(stats, *args, **kwargs)

--- a/fairseq/progress_bar.py
+++ b/fairseq/progress_bar.py
@@ -377,7 +377,8 @@ def progress_bar_print(bar, stats, *args, **kwargs):
     log_xla_metrics = kwargs.pop('log_xla_metrics', False)
     flush_writer = kwargs.pop('flush_writer', False)
     bar.print(stats, *args, **kwargs)
-    if isinstance(bar, tensorboard_log_wrapper_xla) and log_xla_metrics:
-        bar.log_xla_metrics(stats, *args, **kwargs)
-    if flush_writer:
-        bar.flush_writer(kwargs.get('tag'))
+    if isinstance(bar, tensorboard_log_wrapper_xla):
+        if log_xla_metrics:
+            bar.log_xla_metrics(stats, *args, **kwargs)
+        if flush_writer:
+            bar.flush_writer(kwargs.get('tag'))

--- a/train.py
+++ b/train.py
@@ -405,6 +405,14 @@ def main_tpu(args):
         """
         This is the main training loop. It trains for 1 epoch.
         """
+
+        def print_training_update(trainer, progress, args, i, tracker):
+            stats = get_training_stats(trainer, args=args)
+            stats['rate'] = tracker.rate()
+            stats['now'] = now()
+            progress.log(stats, tag='train', step=trainer.get_num_updates())
+            progress.print_mid_epoch(i+1, force=True)
+
         stats, log_output, skip_stat_keys = None, None, {'clip'}
         tracker = xm.RateTracker()
         for i, samples in enumerate(loader, start=epoch_itr.iterations_in_epoch):
@@ -418,13 +426,6 @@ def main_tpu(args):
             if (not (i % args.log_steps)) or (i == last_batch_index-1):
                 step_args = trainer, progress, args, i, tracker
                 xm.add_step_closure(print_training_update, args=step_args)
-
-    def print_training_update(trainer, progress, args, i, tracker):
-        stats = get_training_stats(trainer, args=args)
-        stats['rate'] = tracker.rate()
-        stats['now'] = now()
-        progress.log(stats, step=stats['num_updates'])
-        progress.print_mid_epoch(i+1, force=True)
 
     def valid_loop_fn(
         args, device, trainer, progress, loader, last_batch_index
@@ -472,8 +473,9 @@ def main_tpu(args):
             args, device, trainer, progress,
             para_loader.per_device_loader(device), len(progress) - 1
         )
-        progress.print(
-            stats, tag=subset, step=trainer.get_num_updates(), force=True
+        progress_bar.progress_bar_print(
+            progress, stats, step=trainer.get_num_updates(), force=True,
+            tag='validate-{}'.format(subset),
         )
         xm.master_print('Validated the subset "{}", {}'.format(subset, now()))
         return stats['loss'].avg
@@ -531,7 +533,10 @@ def main_tpu(args):
         )
         training_stats = get_training_stats(trainer, args=args)
         tloss = training_stats['loss'].avg.item()
-        progress.print(training_stats, tag=device, force=True)
+        progress_bar.progress_bar_print(
+            progress, training_stats, tag='train', force=True,
+            step=trainer.get_num_updates(), log_xla_metrics=True
+        )
         xm.master_print('Epoch {} end {}'.format(epoch_itr.epoch, now()))
         if args.metrics_debug:
             xm.master_print(met.metrics_report())

--- a/train.py
+++ b/train.py
@@ -475,7 +475,7 @@ def main_tpu(args):
         )
         progress_bar.progress_bar_print(
             progress, stats, step=trainer.get_num_updates(), force=True,
-            tag='validate-{}'.format(subset),
+            tag='validate-{}'.format(subset), flush_writer=True,
         )
         xm.master_print('Validated the subset "{}", {}'.format(subset, now()))
         return stats['loss'].avg
@@ -535,7 +535,8 @@ def main_tpu(args):
         tloss = training_stats['loss'].avg.item()
         progress_bar.progress_bar_print(
             progress, training_stats, tag='train', force=True,
-            step=trainer.get_num_updates(), log_xla_metrics=True
+            step=trainer.get_num_updates(), log_xla_metrics=True,
+            flush_writer=True,
         )
         xm.master_print('Epoch {} end {}'.format(epoch_itr.epoch, now()))
         if args.metrics_debug:


### PR DESCRIPTION
* added a new tensorboard log wrapper progress bar which behaves in a
compatible way w/ the metrics handler
  * has one summary writer, called "run" (great naming choice by me)
  * prefixes the stats collected by fairseq trainers (such as loss, wall
time, gradient norms etc) by the "tag" passed to the progress_bar
    * e.g.: metric name is "loss", "tag" is "train", it logs
  * logs xla metrics at the end of epochs.
"train-loss" to tensorboard. similarly, "validation-loss", etc.

* if `--metrics_debug` and `--tensorboard-logdir` are passed in, then
`train.py` will use the said progress_bar above.

* call `item()` before going to tensorboardX, as suggested by tensorboardX