### PR TITLE
Replacy numpy.float with python's float to fix test pt-nightly-fs-transformer-func-v3-32-1vm

### DIFF
--- a/fairseq/data/indexed_dataset.py
+++ b/fairseq/data/indexed_dataset.py
@@ -86,7 +86,7 @@ dtypes = {
     3: np.int16,
     4: np.int32,
     5: np.int64,
-    6: np.float,
+    6: float,
     7: np.double,
     8: np.uint16
 }
@@ -289,7 +289,7 @@ class IndexedDatasetBuilder(object):
         np.int16: 2,
         np.int32: 4,
         np.int64: 8,
-        np.float: 4,
+        float: 4,
         np.double: 8
     }
 


### PR DESCRIPTION
`pt-nightly-fs-transformer-func-v3-32-1vm` test fails with error:
```
Traceback (most recent call last):
  File "tpu-examples/deps/fairseq/train.py", line 26, in <module>
    from fairseq import (
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/__init__.py", line 9, in <module>
    import fairseq.criterions  # noqa
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/criterions/__init__.py", line 24, in <module>
    importlib.import_module('fairseq.criterions.' + module)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/criterions/sentence_ranking.py", line 11, in <module>
    from fairseq import utils
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/utils.py", line 20, in <module>
    from fairseq.modules import gelu, gelu_accurate
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/modules/__init__.py", line 9, in <module>
    from .character_token_embedder import CharacterTokenEmbedder
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/modules/character_token_embedder.py", line 14, in <module>
    from fairseq.data import Dictionary
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/data/__init__.py", line 18, in <module>
    from .indexed_dataset import IndexedCachedDataset, IndexedDataset, IndexedRawTextDataset, MMapIndexedDataset
  File "/home/xl-ml-test/tpu-examples/deps/fairseq/fairseq/data/indexed_dataset.py", line 89, in <module>
    6: np.float,
  File "/home/xl-ml-test/.local/lib/python3.8/site-packages/numpy/__init__.py", line 284, in __getattr__
    raise AttributeError("module {!r} has no attribute "
AttributeError: module 'numpy' has no attribute 'float'
``` 
log: https://cloudlogging.app.goo.gl/8eJFZPy5D9E8wMZh7

Per [post](https://stackoverflow.com/questions/74844262/how-to-solve-error-numpy-has-no-attribute-float-in-python), numpy.float has been deprecated in numpy 1.24 hence the error.